### PR TITLE
Replace magic numbers

### DIFF
--- a/maps/mp/bots/_bot_script.gsc
+++ b/maps/mp/bots/_bot_script.gsc
@@ -364,7 +364,7 @@ getCamos()
 			empty_rows = 0;
 		}
 		
-		if ( camo_name == "" )
+		if ( camo_name == "gold" || camo_name == "prestige" )
 		{
 			continue;
 		}

--- a/maps/mp/bots/_bot_script.gsc
+++ b/maps/mp/bots/_bot_script.gsc
@@ -177,14 +177,20 @@ bot_get_rank()
 getCardTitles()
 {
 	cards = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 600; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		card_name = tablelookupbyrow( "mp/cardTitleTable.csv", i, 0 );
 		
 		if ( card_name == "" )
 		{
+			empty_rows++;
 			continue;
+		}
+		else
+		{
+			empty_rows = 0;
 		}
 		
 		if ( !issubstr( card_name, "cardtitle_" ) )
@@ -204,14 +210,20 @@ getCardTitles()
 getCardIcons()
 {
 	cards = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 300; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		card_name = tablelookupbyrow( "mp/cardIconTable.csv", i, 0 );
 		
 		if ( card_name == "" )
 		{
+			empty_rows++;
 			continue;
+		}
+		else
+		{
+			empty_rows = 0;
 		}
 		
 		if ( !issubstr( card_name, "cardicon_" ) )
@@ -249,9 +261,9 @@ getAttachmentsForGun( gun )
 	
 	attachments = [];
 	
-	for ( h = 0; h < 10; h++ )
+	for ( i = 0; true; i++ )
 	{
-		attachmentName = tablelookupbyrow( "mp/statStable.csv", row, h + 11 );
+		attachmentName = tablelookupbyrow( "mp/statStable.csv", row, i + 11 );
 		
 		if ( attachmentName == "" )
 		{
@@ -271,10 +283,21 @@ getAttachmentsForGun( gun )
 getPrimaries()
 {
 	primaries = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 160; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		weapon_type = tablelookupbyrow( "mp/statstable.csv", i, 2 );
+		
+		if ( weapon_type == "" )
+		{
+			empty_rows++;
+			continue;
+		}
+		else
+		{
+			empty_rows = 0;
+		}
 		
 		if ( weapon_type != "weapon_assault" && weapon_type != "weapon_riot" && weapon_type != "weapon_smg" && weapon_type != "weapon_sniper" && weapon_type != "weapon_lmg" )
 		{
@@ -295,10 +318,21 @@ getPrimaries()
 getSecondaries()
 {
 	secondaries = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 160; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		weapon_type = tablelookupbyrow( "mp/statstable.csv", i, 2 );
+		
+		if ( weapon_type == "" )
+		{
+			empty_rows++;
+			continue;
+		}
+		else
+		{
+			empty_rows = 0;
+		}
 		
 		if ( weapon_type != "weapon_pistol" && weapon_type != "weapon_machine_pistol" && weapon_type != "weapon_projectile" && weapon_type != "weapon_shotgun" )
 		{
@@ -324,10 +358,21 @@ getSecondaries()
 getCamos()
 {
 	camos = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 15; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		camo_name = tablelookupbyrow( "mp/camoTable.csv", i, 1 );
+		
+		if ( camo_name == "" )
+		{
+			empty_rows++;
+			continue;
+		}
+		else
+		{
+			empty_rows = 0;
+		}
 		
 		if ( camo_name == "" )
 		{
@@ -346,10 +391,21 @@ getCamos()
 getPerks( perktype )
 {
 	perks = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 50; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		perk_type = tablelookupbyrow( "mp/perktable.csv", i, 5 );
+		
+		if ( perk_type == "" )
+		{
+			empty_rows++;
+			continue;
+		}
+		else
+		{
+			empty_rows = 0;
+		}
 		
 		if ( perk_type != perktype )
 		{
@@ -388,10 +444,21 @@ getKillsNeededForStreak( streak )
 getKillstreaks()
 {
 	killstreaks = [];
+	empty_rows = 0;
 	
-	for ( i = 0; i < 40; i++ )
+	for ( i = 0; empty_rows < 2; i++ )
 	{
 		streak_name = tablelookupbyrow( "mp/killstreakTable.csv", i, 1 );
+		
+		if ( streak_name == "" )
+		{
+			empty_rows++;
+			continue;
+		}
+		else
+		{
+			empty_rows = 0;
+		}
 		
 		if ( streak_name == "" || streak_name == "none" )
 		{

--- a/maps/mp/bots/_bot_script.gsc
+++ b/maps/mp/bots/_bot_script.gsc
@@ -450,22 +450,7 @@ getKillstreaks()
 			empty_rows = 0;
 		}
 		
-		if ( streak_name == "" || streak_name == "none" )
-		{
-			continue;
-		}
-		
-		if ( streak_name == "b1" )
-		{
-			continue;
-		}
-		
-		if ( streak_name == "sentry" ) // theres an airdrop version
-		{
-			continue;
-		}
-		
-		if ( issubstr( streak_name, "KILLSTREAKS_" ) )
+		if ( streak_name == "none" || streak_name == "b1" || streak_name == "sentry" || issubstr( streak_name, "KILLSTREAKS_" )
 		{
 			continue;
 		}

--- a/maps/mp/bots/_bot_script.gsc
+++ b/maps/mp/bots/_bot_script.gsc
@@ -193,11 +193,6 @@ getCardTitles()
 			empty_rows = 0;
 		}
 		
-		if ( !issubstr( card_name, "cardtitle_" ) )
-		{
-			continue;
-		}
-		
 		cards[ cards.size ] = card_name;
 	}
 	

--- a/maps/mp/bots/_bot_script.gsc
+++ b/maps/mp/bots/_bot_script.gsc
@@ -221,11 +221,6 @@ getCardIcons()
 			empty_rows = 0;
 		}
 		
-		if ( !issubstr( card_name, "cardicon_" ) )
-		{
-			continue;
-		}
-		
 		cards[ cards.size ] = card_name;
 	}
 	


### PR DESCRIPTION
This fixes bots no longer using all title cards, in the current state of IW4x lots of veteran and all master title cards are skipped.
The reason is IW4x added new titles which made the table iterator with the magic number function incorrectly.

Card icons are affected too.

Also some optimizations and cleanup.