### PR TITLE
Fix bot fov miscalculation and implement interpolated ads zoom

### DIFF
--- a/maps/mp/bots/_bot_internal.gsc
+++ b/maps/mp/bots/_bot_internal.gsc
@@ -29,7 +29,6 @@ added()
 	self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 2500; // how long a bot ads's when they cant see the target
 	self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 10000; // how long a bot will look at a target's last position
 	self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 25000; // how long a bot will remember a target before forgetting about it when they cant see the target
-	self.pers[ "bots" ][ "skill" ][ "fov" ] = -1; // the fov of the bot, -1 being 360, 1 being 0
 	self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 100000 * 2; // the longest distance a bot will target
 	self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 100000; // the start distance before bot's target abilitys diminish
 	self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0; // how long a bot waits after spawning before targeting, etc
@@ -1338,7 +1337,7 @@ target_loop()
 	myEye = self geteye();
 	theTime = gettime();
 	myAngles = self getplayerangles();
-	myFov = self.pers[ "bots" ][ "skill" ][ "fov" ];
+	myFov = 0.75; // the fov of the bot, -1 being 360, 1 being 0
 	bestTargets = [];
 	bestTime = 2147483647;
 	rememberTime = self.pers[ "bots" ][ "skill" ][ "remember_time" ];
@@ -1348,7 +1347,7 @@ target_loop()
 	ignoreSmoke = issubstr( self getcurrentweapon(), "_thermal_" );
 	vehEnt = undefined;
 	adsAmount = self playerads();
-	adsFovFact = self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ];
+	hasBlastshield = self _hasPerk( "_specialty_blastshield" );
 	
 	if ( usingRemote )
 	{
@@ -1366,7 +1365,43 @@ target_loop()
 	// reduce fov if ads'ing
 	if ( adsAmount > 0 )
 	{
-		myFov *= 1 - adsFovFact * adsAmount;
+		currentWeapon = self GetCurrentWeapon();
+		currentWeaponClass = WeaponClass( currentWeapon );
+		hasThermal = ignoreSmoke;
+		hasAcog = IsSubstr( currentWeapon, "_acog_" );
+		
+		if ( ( hasThermal || currentWeaponClass == "sniper" || currentWeapon == "javelin_mp" )
+			&& !hasAcog
+			&& adsAmount >= 1 )
+		{
+			if ( !hasBlastshield )
+			{
+				myFov = 0.95;
+			}
+			else
+			{
+				myFov = 0.9;
+			}
+		}
+		else if ( hasAcog || currentWeaponClass == "stinger_mp" )
+		{
+			myFov = ( 1 - adsAmount ) * myFov + adsAmount * 0.9;
+		}
+		else if ( currentWeaponClass == "rifle" || currentWeaponClass == "mg" )
+		{
+			myFov = ( 1 - adsAmount ) * myFov + adsAmount * 0.85;
+		}
+		else if ( currentWeaponClass == "smg"
+			|| currentWeaponClass == "spread"
+			|| currentWeaponClass == "rocketlauncher" )
+		{
+			myFov = ( 1 - adsAmount ) * myFov + adsAmount * 0.8;
+		}
+	}
+	
+	if ( hasBlastshield )
+	{
+		myFov += 0.05;
 	}
 	
 	if ( hasTarget && !isdefined( self.bot.target.entity ) )

--- a/maps/mp/bots/_bot_script.gsc
+++ b/maps/mp/bots/_bot_script.gsc
@@ -1428,7 +1428,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 500;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 600;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 750;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.7;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 2500;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 1000;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.75;
@@ -1439,7 +1438,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 4;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 2;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_spineupper,j_ankle_le,j_ankle_ri";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 0;
@@ -1460,7 +1458,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 1000;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 1250;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 1500;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.65;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 3000;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 1500;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.65;
@@ -1471,7 +1468,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 3;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 1.5;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_spineupper,j_ankle_le,j_ankle_ri,j_head";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 10;
@@ -1492,7 +1488,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 1000;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 1500;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 2000;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.6;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 4000;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 2250;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.5;
@@ -1503,7 +1498,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 2.5;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 1;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_spineupper,j_spineupper,j_ankle_le,j_ankle_ri,j_head";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 20;
@@ -1524,7 +1518,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 1500;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 2000;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 3000;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.55;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 5000;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 3350;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.35;
@@ -1535,7 +1528,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 2;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 0.75;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_spineupper,j_spineupper,j_ankle_le,j_ankle_ri,j_head,j_head";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 30;
@@ -1556,7 +1548,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 2500;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 3000;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 4000;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 7500;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 5000;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.25;
@@ -1567,7 +1558,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 1.5;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_spineupper,j_head";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 40;
@@ -1588,7 +1578,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 2500;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 4000;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 5000;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.45;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 10000;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 7500;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.2;
@@ -1599,7 +1588,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 1;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 0.25;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_spineupper,j_head,j_head";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 50;
@@ -1620,7 +1608,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 2500;
 					self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 4000;
 					self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 7500;
-					self.pers[ "bots" ][ "skill" ][ "fov" ] = 0.4;
 					self.pers[ "bots" ][ "skill" ][ "dist_max" ] = 15000;
 					self.pers[ "bots" ][ "skill" ][ "dist_start" ] = 10000;
 					self.pers[ "bots" ][ "skill" ][ "spawn_time" ] = 0.05;
@@ -1631,7 +1618,6 @@ difficulty()
 					self.pers[ "bots" ][ "skill" ][ "aim_offset_amount" ] = 0;
 					self.pers[ "bots" ][ "skill" ][ "bone_update_interval" ] = 0.05;
 					self.pers[ "bots" ][ "skill" ][ "bones" ] = "j_head";
-					self.pers[ "bots" ][ "skill" ][ "ads_fov_multi" ] = 0.5;
 					self.pers[ "bots" ][ "skill" ][ "ads_aimspeed_multi" ] = 0.5;
 					
 					self.pers[ "bots" ][ "behavior" ][ "strafe" ] = 65;
@@ -1675,7 +1661,6 @@ set_diff()
 			self.pers[ "bots" ][ "skill" ][ "remember_time" ] = 50 * randomint( 100 );
 			self.pers[ "bots" ][ "skill" ][ "no_trace_ads_time" ] = 50 * randomint( 100 );
 			self.pers[ "bots" ][ "skill" ][ "no_trace_look_time" ] = 50 * randomint( 100 );
-			self.pers[ "bots" ][ "skill" ][ "fov" ] = randomfloatrange( -1, 1 );
 			
 			randomNum = randomintrange( 500, 25000 );
 			self.pers[ "bots" ][ "skill" ][ "dist_start" ] = randomNum;


### PR DESCRIPTION
The calculation of the bot's view cone when they ADS is wrong. It actually made their view wider instead narrowing it. You could observe this when a bot targeted an enemy, ADS, and then suddenly snap to another target who was out of view.

I also implemented the different zoom levels of all weapon classes with interpolation. The bots view now behave somewhat like vanilla players with the default fov of 65.

I decided to give this value for every difficulty level, since in my opinion, the bots are already difficult enough with their inhuman reaction times and considering the latency advantage against online players.