### PR TITLE
Fix bots seeing cold blooded enemies through smoke with thermal and enemies while EMPed

### DIFF
--- a/maps/mp/bots/_bot_internal.gsc
+++ b/maps/mp/bots/_bot_internal.gsc
@@ -1472,7 +1472,7 @@ target_loop()
 							player checkTraceForBone( myEye, "j_ankle_le" ) ||
 							player checkTraceForBone( myEye, "j_ankle_ri" ) )
 							
-						&& ( ignoreSmoke ||
+						&& ( ignoreSmoke && !self isemped() && !player _hasperk( "specialty_coldblooded" ) ) ||
 							SmokeTrace( myEye, player.origin, level.smokeradius ) ||
 							daDist < level.bots_maxknifedistance * 4 )
 							


### PR DESCRIPTION
Bots with thermal could target players through smoke when they were not supposed to.